### PR TITLE
Reduce the amount of own-goals

### DIFF
--- a/bot/defending.py
+++ b/bot/defending.py
@@ -3,7 +3,7 @@ import math
 
 from rlutilities.linear_algebra import normalize, rotation, vec3, vec2, dot
 from rlutilities.mechanics import Dodge
-from util import line_backline_intersect, cap, distance_2d, sign, get_speed, can_dodge
+from util import line_backline_intersect, cap, distance_2d, sign, get_speed, can_dodge, velocity_2d
 from steps import Step
 
 

--- a/bot/defending.py
+++ b/bot/defending.py
@@ -20,7 +20,7 @@ def defending(agent):
         agent.dodge.duration = 0.1
         agent.dodge.target = target
     if not agent.defending:
-        agent.step = Step.Catching
+        agent.step = (Step.Catching if agent.ball_bouncing else Step.Shooting)
 
 
 def defending_target(agent):
@@ -29,10 +29,7 @@ def defending_target(agent):
     car = agent.info.my_car
     car_to_ball = ball.location - car.location
     backline_intersect = line_backline_intersect(agent.my_goal.center[1], vec2(car.location), vec2(car_to_ball))
-    if backline_intersect < 0:
-        target = agent.my_goal.center - vec3(2000, 0, 0)
-    else:
-        target = agent.my_goal.center + vec3(2000, 0, 0)
+    target = agent.my_goal.center + vec3(sign(backline_intersect) * max(abs(ball.location[0]), 1500), 0, 0)
     target_to_ball = normalize(ball.location - target)
     # Subtract target to car vector
     difference = target_to_ball - normalize(car.location - target)

--- a/bot/defending.py
+++ b/bot/defending.py
@@ -11,6 +11,7 @@ def defending(agent):
     """"Method that gives output for the defending strategy"""
     target = defending_target(agent)
     agent.drive.target = target
+    current_speed = velocity_2d(agent.info.my_car.velocity)
     agent.drive.speed = get_speed(agent, target)
     agent.drive.step(agent.fps)
     agent.controls = agent.drive.controls
@@ -21,6 +22,14 @@ def defending(agent):
         agent.dodge.target = target
     if not agent.defending:
         agent.step = (Step.Catching if agent.ball_bouncing else Step.Shooting)
+    elif agent.drive.speed > current_speed + 300 and 1200 < current_speed < 2000 and agent.info.my_car.boost <= 5\
+              and agent.info.my_car.location[2] < 80\
+              and distance_2d(agent.info.my_car.location, target) > (current_speed + 500) * 1.6:
+        # Dodge towards the shooting target for speed
+        agent.step = Step.Dodge
+        agent.dodge = Dodge(agent.info.my_car)
+        agent.dodge.duration = 0.1
+        agent.dodge.target = target
 
 
 def defending_target(agent):

--- a/bot/derevo.py
+++ b/bot/derevo.py
@@ -16,7 +16,7 @@ from dribble import Dribbling
 from goal import Goal
 from kick_off import init_kickoff, kick_off
 from shooting import shooting
-from util import distance_2d, get_bounce, line_backline_intersect, sign
+from util import distance_2d, get_bounce, line_backline_intersect, sign, velocity_2d
 from steps import Step
 
 
@@ -164,10 +164,12 @@ class Hypebot(BaseAgent):
             defending(self)
         elif self.step is Step.Dodge:
             self.dodge.step(self.fps)
-            self.controls = self.dodge.controls
-            self.controls.boost = 0
             if self.dodge.finished and self.info.my_car.on_ground:
                 self.step = Step.Catching
+            else:
+                self.controls = self.dodge.controls
+                self.controls.boost = 0
+                self.controls.throttle = velocity_2d(self.info.my_car.velocity) < 500
         elif self.step is Step.Shooting:
             shooting(self)
 

--- a/bot/shooting.py
+++ b/bot/shooting.py
@@ -28,7 +28,7 @@ def shooting(agent):
         agent.dodge = Dodge(agent.info.my_car)
         agent.dodge.duration = 0.1
         agent.dodge.target = agent.info.ball.location
-    elif not (abs(agent.info.ball.velocity[2]) < 100
+    elif agent.ball_bouncing and not (abs(agent.info.ball.velocity[2]) < 100
               and sign(agent.team) * agent.info.ball.velocity[1] < 0):
         agent.step = Step.Catching
         agent.drive.target = agent.info.ball.location

--- a/bot/shooting.py
+++ b/bot/shooting.py
@@ -3,7 +3,7 @@ import math
 
 from rlutilities.linear_algebra import normalize, rotation, vec3, vec2, dot, norm
 from rlutilities.mechanics import Dodge
-from util import cap, distance_2d, sign, line_backline_intersect, get_speed
+from util import cap, distance_2d, sign, line_backline_intersect, get_speed, velocity_2d
 from steps import Step
 
 
@@ -22,6 +22,7 @@ def shooting(agent):
     agent.controls = agent.drive.controls
     target = shooting_target(agent)
     agent.drive.target = target
+    current_speed = velocity_2d(agent.info.my_car.velocity)
     agent.drive.speed = get_speed(agent, target)
     if should_dodge(agent):
         agent.step = Step.Dodge
@@ -33,6 +34,14 @@ def shooting(agent):
         agent.step = Step.Catching
         agent.drive.target = agent.info.ball.location
         agent.drive.speed = 1399
+    elif agent.drive.speed > current_speed + 300 and 1200 < current_speed < 2000 and agent.info.my_car.boost <= 5\
+              and agent.info.my_car.location[2] < 80\
+              and distance_2d(agent.info.my_car.location, target) > (current_speed + 500) * 1.6:
+        # Dodge towards the shooting target for speed
+        agent.step = Step.Dodge
+        agent.dodge = Dodge(agent.info.my_car)
+        agent.dodge.duration = 0.1
+        agent.dodge.target = target
 
 
 def shooting_target(agent):
@@ -42,9 +51,9 @@ def shooting_target(agent):
     car_to_ball = ball.location - car.location
     backline_intersect = line_backline_intersect(
         agent.their_goal.center[1], vec2(car.location), vec2(car_to_ball))
-    if -500 < backline_intersect < 500:
+    if abs(backline_intersect) < 700:
         goal_to_ball = normalize(car.location - ball.location)
-        error = cap(distance_2d(ball.location, car.location) / 1000, 0, 1)
+        error = 0
     else:
         # Right of the ball
         if -500 > backline_intersect:
@@ -55,7 +64,7 @@ def shooting_target(agent):
         goal_to_ball = normalize(ball.location - target)
         # Subtract the goal to car vector
         difference = goal_to_ball - normalize(car.location - target)
-        error = cap(abs(difference[0]) + abs(difference[1]), 1, 10)
+        error = cap(abs(difference[0]) + abs(difference[1]), 0, 5)
 
     goal_to_ball_2d = vec2(goal_to_ball[0], goal_to_ball[1])
     test_vector_2d = dot(rotation(0.5 * math.pi), goal_to_ball_2d)
@@ -89,6 +98,6 @@ def should_dodge(agent):
     bot_to_target = agent.info.ball.location - car.location
     local_bot_to_target = dot(bot_to_target, agent.info.my_car.rotation)
     angle_front_to_target = math.atan2(local_bot_to_target[1], local_bot_to_target[0])
-    close_to_ball = norm(vec2(bot_to_target)) < 850
-    good_angle = math.radians(-10) < angle_front_to_target < math.radians(10)
+    close_to_ball = norm(vec2(bot_to_target)) < 750
+    good_angle = abs(angle_front_to_target) < math.radians(15)
     return close_to_ball and close_to_goal and aiming_for_goal and good_angle


### PR DESCRIPTION
It seemed to be caused by a sign-mismatch in the defending state, and this was not helped by catching state being erroneously switched to.